### PR TITLE
Upgrade to 0.13 using web sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-default = ["console_error_panic_hook"]
-
 [dependencies]
 log = "0.4"
 strum = "0.17"
@@ -19,12 +16,6 @@ serde_derive = "1"
 wasm-bindgen = "0.2.58"
 web_logger = "0.2"
 yew = { version = "0.13", features = ["web_sys"] }
-
-# The `console_error_panic_hook` crate provides better debugging of panics by
-# logging them with `console.error`. This is great for development, but requires
-# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
-# code size when deploying.
-console_error_panic_hook = { version = "0.1.6", optional = true }
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ strum = "0.17"
 strum_macros = "0.17"
 serde = "1"
 serde_derive = "1"
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.58"
 web_logger = "0.2"
-yew = "0.12"
+yew = { version = "0.13", features = ["web_sys"] }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -33,3 +33,9 @@ wee_alloc = { version = "0.4.4", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
+
+[dependencies.web-sys]
+version = "0.3.4"
+features = [
+  'KeyboardEvent',
+]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@wasm-tool/wasm-pack-plugin": "^1.0.0",
     "copy-webpack-plugin": "^5.0.4",
     "webpack": "^4.29.3",
-    "webpack-cli": "^3.1.2",
+    "webpack-cli": "^3.3.11",
     "webpack-dev-server": "^3.7.2"
   }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,7 +6,7 @@ use yew::format::Json;
 use yew::services::storage::{Area, StorageService};
 use yew::prelude::*;
 
-const KEY: &'static str = "yew.todomvc.self";
+const KEY: &str = "yew.todomvc.self";
 
 pub struct App {
     link: ComponentLink<Self>,
@@ -48,7 +48,7 @@ impl Component for App {
     type Properties = ();
 
     fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
-        let storage = StorageService::new(Area::Local);
+        let storage = StorageService::new(Area::Local).unwrap();
         let entries = {
             if let Json(Ok(restored_entries)) = storage.restore(KEY) {
                 restored_entries
@@ -159,7 +159,7 @@ impl Component for App {
 impl App {
     fn view_filter(&self, filter: Filter) -> Html {
         let flt = filter.clone();
-        
+
         html! {
             <li>
                 <a class=if self.state.filter == flt { "selected" } else { "not-selected" }
@@ -179,7 +179,7 @@ impl App {
                    placeholder="What needs to be done?"
                    value=&self.state.value
                    oninput=self.link.callback(|e: InputData| Msg::Update(e.value))
-                   onkeypress=self.link.callback(|e: KeyPressEvent| {
+                   onkeypress=self.link.callback(|e: KeyboardEvent| {
                        if e.key() == "Enter" { Msg::Add } else { Msg::Nope }
                    }) />
             /* Or multiline:
@@ -210,7 +210,7 @@ impl App {
             </li>
         }
     }
-    
+
     fn view_entry_edit_input(&self, (idx, entry): (&usize, &Entry)) -> Html {
         let idx = *idx;
         if entry.editing {
@@ -220,7 +220,7 @@ impl App {
                        value=&entry.description
                        oninput=self.link.callback(move |e: InputData| Msg::UpdateEdit(e.value))
                        onblur=self.link.callback(move |_| Msg::Edit(idx))
-                       onkeypress=self.link.callback(move |e: KeyPressEvent| {
+                       onkeypress=self.link.callback(move |e: KeyboardEvent| {
                           if e.key() == "Enter" { Msg::Edit(idx) } else { Msg::Nope }
                        }) />
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,10 +3758,10 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webpack-cli@^3.1.2:
-  version "3.3.6"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.6.tgz#2c8c399a2642133f8d736a359007a052e060032c"
-  integrity sha512-0vEa83M7kJtxK/jUhlpZ27WHIOndz5mghWL2O53kiDoA9DIxSKnfqB92LoqEn77cT4f3H2cZm1BMEat/6AZz3A==
+webpack-cli@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.3.11.tgz#3bf21889bf597b5d82c38f215135a411edfdc631"
+  integrity sha512-dXlfuml7xvAFwYUPsrtQAA9e4DOe58gnzSxhgrO/ZM/gyXTBowrsYeubyN4mqGhYdpXMFNyQ6emjJS9M7OBd4g==
   dependencies:
     chalk "2.4.2"
     cross-spawn "6.0.5"


### PR DESCRIPTION
Upgrade `yew-wasm-pack-template` to make use of yew 0.13 as well as the new `web_sys` functionality.

`yarn run build` builds successfully

Running with `yarn run start:dev`, runs as expected
