### PR TITLE
Update to yew 0.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       chrome: stable
     before_script:
       - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.5" cargo-generate)
       - cargo install-update -a
       - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
     script:
@@ -31,7 +31,7 @@ matrix:
     env: RUST_BACKTRACE=1
     before_script:
       - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.5" cargo-generate)
       - cargo install-update -a
       - rustup target add wasm32-unknown-unknown
     script:
@@ -52,7 +52,7 @@ matrix:
     env: RUST_BACKTRACE=1
     before_script:
       - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.5" cargo-generate)
       - cargo install-update -a
       - rustup target add wasm32-unknown-unknown
     script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew-wasm-pack-template"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Justin Starry <justin.starry@icloud.com"]
 edition = "2018"
 
@@ -15,7 +15,7 @@ serde = "1"
 serde_derive = "1"
 wasm-bindgen = "0.2.58"
 web_logger = "0.2"
-yew = { version = "0.13", features = ["web_sys"] }
+yew = { version = "0.15" }
 
 # `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
 # compared to the default allocator's ~10K. It is slower than the default


### PR DESCRIPTION
`yew` now uses `web-sys` by default so I've removed that configuration.

[Reference to the release of yew 0.15.0. ](https://github.com/yewstack/yew/releases/tag/0.15.0)