### PR TITLE
rename script start:dev to dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ yarn run build
 ### 🔬 Serve locally
 
 ```
-yarn run start:dev
+yarn run dev
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "webpack --mode development",
+    "dev": "webpack-dev-server --mode development",
     "build": "webpack --mode production",
-    "start:dev": "webpack-dev-server --mode development"
+    "build:dev": "webpack --mode development",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
     "@wasm-tool/wasm-pack-plugin": "^1.1.0",


### PR DESCRIPTION
`npm run dev` is easier to type than `npm run start:dev`

its the most-used command, so should be short
