### PR TITLE
Enable historyApiFallback for webpack devServer config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ const distPath = path.resolve(__dirname, "dist");
 module.exports = (env, argv) => {
   return {
     devServer: {
+      historyApiFallback: true,
       contentBase: distPath,
       compress: argv.mode === 'production',
       port: 8000

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,16 +6,17 @@ const distPath = path.resolve(__dirname, "dist");
 module.exports = (env, argv) => {
   return {
     devServer: {
-      historyApiFallback: true,
       contentBase: distPath,
       compress: argv.mode === 'production',
-      port: 8000
+      port: 8000,
+      historyApiFallback: true
     },
     entry: './bootstrap.js',
     output: {
       path: distPath,
       filename: "todomvc.js",
-      webassemblyModuleFilename: "todomvc.wasm"
+      webassemblyModuleFilename: "todomvc.wasm",
+      publicPath: "/"
     },
     module: {
       rules: [


### PR DESCRIPTION
It is very confusing when you try to use yew-router on this template and it doesn’t work by default config.