### PR TITLE
Webpack 5 changes to WebAssembly

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,9 @@ module.exports = (env, argv) => {
         },
       ],
     },
+    experiments: {
+      asyncWebAssembly: true
+    },
     plugins: [
       new CopyWebpackPlugin({
         patterns: [


### PR DESCRIPTION
Webpack 5 requires that WebAssembly modules be flagged with either `asyncWebassembly: true` for the newer spec or (deprecated) `syncWebAssembly: true` for WebPack 4 implementation.

https://webpack.js.org/configuration/experiments/